### PR TITLE
feat: add gap in docs component nav

### DIFF
--- a/src/routes/docs/[component]/+layout.svelte
+++ b/src/routes/docs/[component]/+layout.svelte
@@ -21,7 +21,7 @@
 
 <div class="flex grid-cols-12 flex-col gap-8 overflow-hidden py-6 lg:grid lg:px-4">
 	<div class="col-span-2">
-		<ul class="flex w-full overflow-x-auto px-4 pb-2 lg:block lg:px-0">
+		<ul class="flex w-full overflow-x-auto px-4 pb-2 gap-2 lg:block lg:px-0 lg:space-y-2 lg:gap-0">
 			{#each links as link}
 				<li>
 					<a


### PR DESCRIPTION
Adds a little spacing on the docs component nav. On page transitions you can see both the hover state and default buttons glued together. I thought adding a little spacing makes it look nicer 😄 

Tested on chrome desktop and safari latest (macOS).

After screenshots:

<img width="296" alt="Screenshot 2023-04-25 at 10 35 30" src="https://user-images.githubusercontent.com/20280618/234238230-2be2b848-2c45-4eff-a330-d54d08f9d688.png">

<img width="676" alt="Screenshot 2023-04-25 at 10 37 12" src="https://user-images.githubusercontent.com/20280618/234238241-7d68eade-0ba0-4152-a415-74a7dafeab5e.png">
