### PR TITLE
Feature: Add Stackblitz link to the issue template for interactive examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,3 +36,5 @@ If applicable, add screenshots to help explain your problem.
 
 **Additional context**
 Add any other context about the problem here.
+
+To reproduce using Stackblitz, use this [template](https://stackblitz.com/edit/node-rvtbvk?file=package.json) and modify the `src/routes/+page.svelte` file.

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -22,10 +22,10 @@
 </script>
 
 <main class="flex min-h-screen flex-col">
-	<nav class="flex items-center justify-between gap-2 border-b border-zinc-400 px-2 lg:px-4 py-2">
-		<a class="flex items-center gap-2 lg:text-xl font-sans font-bold" href="/">
+	<nav class="flex items-center justify-between gap-2 border-b border-zinc-400 px-2 py-2 lg:px-4">
+		<a class="flex items-center gap-2 font-sans font-bold lg:text-xl" href="/">
 			<img
-				class="w-7 h-7 lg:h-9 lg:w-9 rounded-sm object-contain"
+				class="h-7 w-7 rounded-sm object-contain lg:h-9 lg:w-9"
 				src="/logo.svg"
 				alt="Radix and Svelte logos"
 			/>


### PR DESCRIPTION
**Feature Request**
To improve the user experience when reporting issues or seeking help, I propose adding a Stackblitz link with a pre-configured Radix environment to the GitHub issue template. This will enable users to create and share minimal reproducible examples with ease.

**Benefits**
- Simplifies the process of sharing code examples when reporting issues or asking questions.
- Encourages users to provide reproducible examples, helping maintainers diagnose and resolve issues more effectively.
- Offers users an interactive environment to experiment with Radix without setting up a local development environment.

**Implementation**
I have prepared a basic Stackblitz template for Radix [here](https://stackblitz.com/edit/node-rvtbvk?file=package.json). If approved, I will add this link to the appropriate issue template(s). Any suggestions or refinements are welcome. Thank you for considering this feature request!
