### PR TITLE
fix: missing types on slider component

### DIFF
--- a/src/lib/components/Avatar/image.svelte
+++ b/src/lib/components/Avatar/image.svelte
@@ -1,11 +1,9 @@
 <script lang="ts" context="module">
 	import { useActions } from '$lib/internal/helpers/useActions';
-
 	import { isMountedStore } from '$lib/internal/stores';
-	import type { BaseProps } from '$lib/internal/types';
+	import type { BaseProps, UnwrapCustomEvents, WrapWithCustomEvent } from '$lib/internal/types';
 	import { getAvatarRootContext, type ImageLoadingStatus } from './root.svelte';
 	import { createEventDispatcher } from 'svelte';
-	import type { Detailed } from '$lib/internal/types';
 
 	export type AvatarImageProps = BaseProps<'img'> & {
 		src?: string;
@@ -18,10 +16,10 @@
 	export let src: $$Props['src'] = undefined;
 	export let alt: $$Props['alt'] = undefined;
 
-	type $$Events = {
-		loadingStatusChange: CustomEvent<ImageLoadingStatus>;
-	};
-	const dispatch = createEventDispatcher<Detailed<$$Events>>();
+	type $$Events = WrapWithCustomEvent<{
+		loadingStatusChange: ImageLoadingStatus;
+	}>;
+	const dispatch = createEventDispatcher<UnwrapCustomEvents<$$Events>>();
 
 	$: if ($rootCtx.imageLoadingStatus !== 'idle') {
 		dispatch('loadingStatusChange', $rootCtx.imageLoadingStatus);

--- a/src/lib/components/Slider/root.svelte
+++ b/src/lib/components/Slider/root.svelte
@@ -2,7 +2,7 @@
 	import { clamp } from '$lib/internal/helpers/numbers';
 	import { reactiveContext } from '$lib/internal/helpers/reactiveContext';
 	import { uniqueContext } from '$lib/internal/helpers/uniqueContext';
-	import type { BaseProps } from '$lib/internal/types';
+	import type { BaseProps, UnwrapCustomEvents, WrapWithCustomEvent } from '$lib/internal/types';
 	import { createEventDispatcher } from 'svelte';
 	import { writable, type Writable } from 'svelte/store';
 
@@ -77,10 +77,11 @@
 	export let orientation: NonNullable<$$Props['orientation']> = 'horizontal';
 	export let name: $$Props['name'] = undefined;
 
-	const dispatch = createEventDispatcher<{
+	type $$Events = WrapWithCustomEvent<{
 		valueCommit: number[];
 		valueChange: number[];
-	}>();
+	}>;
+	const dispatch = createEventDispatcher<UnwrapCustomEvents<$$Events>>();
 
 	// Create root context with initial values
 	const contextStore = setContext({

--- a/src/lib/components/Toggle/root.svelte
+++ b/src/lib/components/Toggle/root.svelte
@@ -1,6 +1,6 @@
 <script lang="ts" context="module">
 	import { useActions } from '$lib/internal/helpers/useActions';
-	import type { BaseProps, Detailed } from '$lib/internal/types';
+	import type { BaseProps, UnwrapCustomEvents, WrapWithCustomEvent } from '$lib/internal/types';
 	import { createEventDispatcher } from 'svelte';
 
 	export type ToggleRootProps = BaseProps<'button'> & {
@@ -17,10 +17,10 @@
 	export let pressed: $$Props['pressed'] = false;
 	export let disabled: $$Props['disabled'] = false;
 
-	type $$Events = {
-		change: CustomEvent<boolean>;
-	};
-	const dispatch = createEventDispatcher<Detailed<$$Events>>();
+	type $$Events = WrapWithCustomEvent<{
+		change: boolean;
+	}>;
+	const dispatch = createEventDispatcher<UnwrapCustomEvents<$$Events>>();
 	export let use: $$Props['use'] = [];
 </script>
 

--- a/src/lib/internal/types.ts
+++ b/src/lib/internal/types.ts
@@ -8,10 +8,29 @@ export type IfEquals<T, U, Y = unknown, N = never> = (<G>() => G extends T ? 1 :
 	? Y
 	: N;
 
-// Type that maps a record of custom events to their payload
-// e.g. Detailed<{change: CustomEvent<string>}> should be {change: string}
-export type Detailed<T> = {
+/**
+ * UnwrapCustomEvents is a utility type that maps through each property of the given type `T`,
+ * and checks if the property type extends CustomEvent. If it does, it extracts the generic type
+ * parameter of CustomEvent (i.e., `U`). Otherwise, it keeps the original property type.
+ *
+ * This type is useful for extracting the details object from CustomEvent types.
+ *
+ * @template T - The input object type with properties to be mapped and checked.
+ */
+export type UnwrapCustomEvents<T> = {
 	[K in keyof T]: T[K] extends CustomEvent<infer U> ? U : T[K];
+};
+/**
+ * WrapWithCustomEvent is a utility type that maps through each property of the given
+ * type `T`, and wraps the property type with CustomEvent, effectively transforming the property
+ * type into CustomEvent<T[K]>.
+ *
+ * This type is useful for wrapping the properties of a type with CustomEvent.
+ *
+ * @template T - The input object type with properties to be mapped and wrapped.
+ */
+export type WrapWithCustomEvent<T> = {
+	[K in keyof T]: CustomEvent<T[K]>;
 };
 
 export type Nullable<T> = T | null;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -22,10 +22,10 @@
 </script>
 
 <main class="flex min-h-screen flex-col">
-	<nav class="flex items-center justify-between gap-2 border-b border-zinc-400 px-2 lg:px-4 py-2">
-		<a class="flex items-center gap-2 lg:text-xl font-sans font-bold" href="/">
+	<nav class="flex items-center justify-between gap-2 border-b border-zinc-400 px-2 py-2 lg:px-4">
+		<a class="flex items-center gap-2 font-sans font-bold lg:text-xl" href="/">
 			<img
-				class="w-7 h-7 lg:h-9 lg:w-9 rounded-sm object-contain"
+				class="h-7 w-7 rounded-sm object-contain lg:h-9 lg:w-9"
 				src="/logo.svg"
 				alt="Radix and Svelte logos"
 			/>


### PR DESCRIPTION
I moved the SliderEvents root types to the $$Events variable, to enable type-safety for custom events.

(The custom-events type was only missing in the compiled output)

**Before, Slider/root.svelte.d.ts**
```
declare const __propDef: {
    props: { },
    events: {
        [evt: string]: CustomEvent<any>;
    };
```

**After, Slider/root.svelte.d.ts**
```
declare const __propDef: {
    props: { },
    events: CustomEventify<{
        valueCommit: number[];
        valueChange: number[];
    }>;
```