### PR TITLE
Increase accessibility of Toggle and update Docs

### DIFF
--- a/src/lib/components/Toggle/root.svelte
+++ b/src/lib/components/Toggle/root.svelte
@@ -14,8 +14,8 @@
 <script lang="ts">
 	type $$Props = ToggleRootProps;
 
-	export let pressed = false;
-	export let disabled = false;
+	export let pressed: $$Props['pressed'] = false;
+	export let disabled: $$Props['disabled'] = false;
 
 	type $$Events = WrapWithCustomEvent<{
 		change: boolean;

--- a/src/lib/components/Toggle/root.svelte
+++ b/src/lib/components/Toggle/root.svelte
@@ -25,11 +25,13 @@
 </script>
 
 <button
+	type="button"
 	{disabled}
 	on:click={() => {
 		pressed = !pressed;
 		dispatch('change', pressed);
 	}}
+	aria-pressed={pressed}
 	data-state={pressed ? 'on' : 'off'}
 	data-disabled={disabled ? '' : undefined}
 	use:useActions={use ?? []}

--- a/src/lib/components/Toggle/root.svelte
+++ b/src/lib/components/Toggle/root.svelte
@@ -14,8 +14,8 @@
 <script lang="ts">
 	type $$Props = ToggleRootProps;
 
-	export let pressed: $$Props['pressed'] = false;
-	export let disabled: $$Props['disabled'] = false;
+	export let pressed = false;
+	export let disabled = false;
 
 	type $$Events = WrapWithCustomEvent<{
 		change: boolean;

--- a/src/lib/components/ToggleGroup/item.svelte
+++ b/src/lib/components/ToggleGroup/item.svelte
@@ -13,7 +13,7 @@
 	type $$Props = ToggleGroupItemProps;
 	export let use: $$Props['use'] = [];
 	export let value: $$Props['value'];
-	export let disabled = false;
+	export let disabled: $$Props['disabled'] = false;
 
 	const rootCtx = getToggleGroupRootContext();
 	const itemCollection = getToggleGroupItemCollection();

--- a/src/lib/components/ToggleGroup/item.svelte
+++ b/src/lib/components/ToggleGroup/item.svelte
@@ -13,7 +13,7 @@
 	type $$Props = ToggleGroupItemProps;
 	export let use: $$Props['use'] = [];
 	export let value: $$Props['value'];
-	export let disabled: $$Props['disabled'] = false;
+	export let disabled = false;
 
 	const rootCtx = getToggleGroupRootContext();
 	const itemCollection = getToggleGroupItemCollection();

--- a/src/lib/components/ToggleGroup/root.svelte
+++ b/src/lib/components/ToggleGroup/root.svelte
@@ -63,13 +63,13 @@
 
 <script lang="ts">
 	type $$Props = ToggleGroupRootProps;
-	export let type: Type = defaults.type;
+	export let type: $$Props['type'] = defaults.type;
 	export let value: $$Props['value'] = null;
-	export let rovingFocus: boolean = defaults.rovingFocus;
-	export let orientation: Orientation = defaults.orientation;
-	export let dir: Direction = defaults.dir;
-	export let loop: boolean = defaults.loop;
-	export let disabled: boolean = defaults.disabled;
+	export let rovingFocus: $$Props['rovingFocus'] = defaults.rovingFocus;
+	export let orientation: $$Props['orientation'] = defaults.orientation;
+	export let dir: $$Props['dir'] = defaults.dir;
+	export let loop: $$Props['loop'] = defaults.loop;
+	export let disabled: $$Props['disabled'] = defaults.disabled;
 	export let role: $$Props['role'] = defaults.role;
 
 	const ctx = setContext({

--- a/src/lib/components/ToggleGroup/root.svelte
+++ b/src/lib/components/ToggleGroup/root.svelte
@@ -50,7 +50,6 @@
 		readonly loop: boolean;
 		readonly rovingFocus: boolean;
 		readonly disabled: ToggleGroupRootProps['disabled'];
-		readonly role: ToggleGroupRootProps['role'];
 		value: ToggleGroupRootProps['value'];
 	};
 
@@ -79,7 +78,6 @@
 		loop: [loop ?? defaults.loop],
 		rovingFocus: [rovingFocus ?? defaults.rovingFocus],
 		disabled: [false],
-		role: ['group'],
 		value: [value, (v) => (value = v)],
 	});
 	$: ctx.set({
@@ -89,7 +87,6 @@
 		loop: loop ?? defaults.loop,
 		rovingFocus: rovingFocus ?? defaults.rovingFocus,
 		disabled: disabled ?? defaults.disabled,
-		role: role ?? defaults.role,
 		value,
 	});
 

--- a/src/lib/components/ToggleGroup/root.svelte
+++ b/src/lib/components/ToggleGroup/root.svelte
@@ -38,6 +38,7 @@
 		loop: true,
 		rovingFocus: true,
 		disabled: false,
+		role: 'group',
 	} satisfies {
 		[key in keyof ToggleGroupRootProps]?: ToggleGroupRootProps[key];
 	};
@@ -49,6 +50,7 @@
 		readonly loop: boolean;
 		readonly rovingFocus: boolean;
 		readonly disabled: ToggleGroupRootProps['disabled'];
+		readonly role: ToggleGroupRootProps['role'];
 		value: ToggleGroupRootProps['value'];
 	};
 
@@ -68,6 +70,7 @@
 	export let dir: Direction = defaults.dir;
 	export let loop: boolean = defaults.loop;
 	export let disabled: boolean = defaults.disabled;
+	export let role: $$Props['role'] = defaults.role;
 
 	const ctx = setContext({
 		type: [type ?? defaults.type],
@@ -76,6 +79,7 @@
 		loop: [loop ?? defaults.loop],
 		rovingFocus: [rovingFocus ?? defaults.rovingFocus],
 		disabled: [false],
+		role: ['group'],
 		value: [value, (v) => (value = v)],
 	});
 	$: ctx.set({
@@ -85,6 +89,7 @@
 		loop: loop ?? defaults.loop,
 		rovingFocus: rovingFocus ?? defaults.rovingFocus,
 		disabled: disabled ?? defaults.disabled,
+		role: role ?? defaults.role,
 		value,
 	});
 
@@ -128,6 +133,6 @@
 	});
 </script>
 
-<div {dir} {...$$restProps} use:useActions={$$restProps.use} data-orientation={orientation}>
+<div {role} {dir} {...$$restProps} use:useActions={$$restProps.use} data-orientation={orientation}>
 	<slot />
 </div>

--- a/src/lib/components/ToggleGroup/root.svelte
+++ b/src/lib/components/ToggleGroup/root.svelte
@@ -61,13 +61,13 @@
 
 <script lang="ts">
 	type $$Props = ToggleGroupRootProps;
-	export let type: $$Props['type'] = defaults.type;
+	export let type: Type = defaults.type;
 	export let value: $$Props['value'] = null;
-	export let rovingFocus: $$Props['rovingFocus'] = defaults.rovingFocus;
-	export let orientation: $$Props['orientation'] = defaults.orientation;
-	export let dir: $$Props['dir'] = defaults.dir;
-	export let loop: $$Props['loop'] = defaults.loop;
-	export let disabled: $$Props['disabled'] = defaults.disabled;
+	export let rovingFocus: boolean = defaults.rovingFocus;
+	export let orientation: Orientation = defaults.orientation;
+	export let dir: Direction = defaults.dir;
+	export let loop: boolean = defaults.loop;
+	export let disabled: boolean = defaults.disabled;
 
 	const ctx = setContext({
 		type: [type ?? defaults.type],

--- a/src/routes/(previews)/Toggle/example.svelte
+++ b/src/routes/(previews)/Toggle/example.svelte
@@ -10,11 +10,9 @@
 
 <Toggle.Root
 	aria-label="Toggle italic"
-	class="grid h-9 w-9 place-items-center items-center
-	justify-center rounded bg-white text-base leading-4 text-vermilion-800 shadow-lg
-	hover:bg-vermilion-100 focus:ring-2 focus:ring-black
-	data-[state=on]:bg-vermilion-200 data-[state=on]:text-vermilion-900"
+	class="grid justify-center items-center place-items-center w-9 h-9 text-base leading-4 bg-white rounded shadow-lg focus:ring-2 focus:ring-black text-vermilion-800 data-[disabled]:cursor-not-allowed data-[state=on]:bg-vermilion-200 data-[state=on]:text-vermilion-900 hover:bg-vermilion-100"
 	bind:pressed={propsObj.Root.pressed}
+	bind:disabled={propsObj.Root.disabled}
 >
 	<Italic />
 </Toggle.Root>

--- a/src/routes/(previews)/Toggle/schema.ts
+++ b/src/routes/(previews)/Toggle/schema.ts
@@ -15,6 +15,17 @@ export const schema = {
 				pressed: {
 					type: 'boolean',
 				},
+				disabled: {
+					type: 'boolean',
+				},
+			},
+			dataAttributes: {
+				'data-disabled': {
+					values: 'Present when disabled',
+				},
+				'data-state': {
+					values: ['on', 'off'],
+				},
 			},
 		},
 	},

--- a/src/routes/(previews)/ToggleGroup/example.svelte
+++ b/src/routes/(previews)/ToggleGroup/example.svelte
@@ -60,6 +60,10 @@
 		}
 	}
 
+	.contents :global(.toggle-item[data-disabled]) {
+		@apply cursor-not-allowed;
+	}
+
 	.contents :global(.toggle-item[data-orientation='horizontal']:dir(ltr)) {
 		@apply border-x border-l-transparent  border-r-vermilion-200;
 

--- a/src/routes/(previews)/ToggleGroup/schema.ts
+++ b/src/routes/(previews)/ToggleGroup/schema.ts
@@ -62,14 +62,14 @@ export const schema = {
 				},
 			},
 			dataAttributes: {
+				'data-disabled': {
+					values: 'Present when disabled',
+				},
 				'data-orientation': {
 					values: ['horizontal', 'vertical'],
 				},
 				'data-state': {
 					values: ['on', 'off'],
-				},
-				'data-disabled': {
-					values: ['true', 'false'],
 				},
 			},
 		},


### PR DESCRIPTION
# Increase accessibility of Toggle and update Docs

This PR increases the accessibility of the Toggle and ToggleGroup components.

## Toggle 
- Includes aria-pressed and type=‘button’ as attributes, as discussed in #121 

## Toggle Group

- add prop `role`, that defaults to `'group'`.
  - This is consistent with Radix UI. 
  - allows users to change the role in the rare cases where `group` might not be an appropriate role.

## Type Inference in Toggle and ToggleGroup

The only changes that might be objectionable are in commit 813abbab1645832ca6815a8eed35581ae60e0623. I explicitly set the props types instead of inferring from `$$Props` as it was incorrectly inferring that the variable could be `undefined`.

- It can be undefined outside of the component but not within the component.