### PR TITLE
feat: When opening the Dialog, preserves the scrollbar "gap"

### DIFF
--- a/src/lib/internal/actions/removeScroll.ts
+++ b/src/lib/internal/actions/removeScroll.ts
@@ -4,9 +4,15 @@ type Params = {
 	disable?: boolean;
 };
 
+export const getScrollbarWidth = () => {
+	return window.innerWidth - document.documentElement.clientWidth;
+};
+
 export const removeScroll = ((node, params) => {
 	const update = (params: Params) => {
+		const scrollbarWidth = getScrollbarWidth();
 		document.body.style.overflow = params.disable ? 'initial' : 'hidden';
+		document.body.style.paddingRight = params.disable ? '' : scrollbarWidth + 'px';
 	};
 
 	update(params);


### PR DESCRIPTION
before:
<img width="1035" alt="before" src="https://user-images.githubusercontent.com/127771606/235910429-79c211df-bd3a-4c5e-8a2c-b139155ea978.png">


afeter:
<img width="1035" alt="after" src="https://user-images.githubusercontent.com/127771606/235910461-e61ccbc8-cf51-4d65-ba1f-1c13da318a2e.png">
