### PR TITLE
feat: When opening the Dialog, preserves the scrollbar "gap"

### DIFF
--- a/src/lib/internal/actions/removeScroll.ts
+++ b/src/lib/internal/actions/removeScroll.ts
@@ -4,9 +4,15 @@ type Params = {
 	disable?: boolean;
 };
 
+const getScrollbarWidth = () => {
+	return window.innerWidth - document.documentElement.clientWidth;
+};
+
 export const removeScroll = ((node, params) => {
 	const update = (params: Params) => {
+		const scrollbarWidth = getScrollbarWidth();
 		document.body.style.overflow = params.disable ? 'initial' : 'hidden';
+		document.body.style.paddingRight = params.disable ? '' : scrollbarWidth + 'px';
 	};
 
 	update(params);


### PR DESCRIPTION
before:
<img width="1035" alt="before" src="https://user-images.githubusercontent.com/127771606/235918285-df075b54-ffc9-4c64-a0a7-a4b510f94543.png">

after:
<img width="1035" alt="after" src="https://user-images.githubusercontent.com/127771606/235918313-a0ec440c-fce4-4327-b147-e17ad5883497.png">

Content no longer jitters. ❤️