### PR TITLE
Mobile-friendly docs

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -46,7 +46,7 @@
 <main class="flex min-h-screen flex-col">
 	<nav
 		class={cn(
-			'flex items-center justify-between px-4 py-4 lg:px-8 ',
+			'flex items-center justify-between px-4 py-4 md:px-8 ',
 			!isRoot && 'border-b border-b-zinc-700'
 		)}
 	>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -14,6 +14,7 @@
 
 	import GitHub from '~icons/simple-icons/github';
 	import Discord from '~icons/simple-icons/discord';
+	import Book from '~icons/lucide/book';
 	import { cn } from './helpers';
 	import { page } from '$app/stores';
 	import { onMount } from 'svelte';
@@ -31,7 +32,7 @@
 <main class="flex min-h-screen flex-col">
 	<nav
 		class={cn(
-			'flex items-center justify-between px-4 py-3 lg:px-6',
+			'flex items-center justify-between px-4 py-4 md:px-6 ',
 			!isRoot && 'border-b border-b-zinc-700'
 		)}
 	>
@@ -47,21 +48,23 @@
 
 		<div class="flex flex-row gap-4">
 			<a href="https://github.com/TGlide/radix-svelte" target="_blank" class="link">
-				<span class="hidden lg:block">GitHub</span>
+				<span class="hidden md:block">GitHub</span>
 				<GitHub
-					class="h-6 w-6 text-white opacity-75 hover:opacity-100 active:translate-y-px lg:hidden"
+					class="h-6 w-6 text-white opacity-75 hover:opacity-100 active:translate-y-px md:hidden"
 				/>
 			</a>
 			<a href="https://discord.com/invite/gQrpPs34xH" target="_blank" class="link">
-				<span class="hidden lg:block">Discord</span>
+				<span class="hidden md:block">Discord</span>
 				<Discord
-					class="h-6 w-6 text-white opacity-75 hover:opacity-100 active:translate-y-px lg:hidden"
+					class="h-6 w-6 text-white opacity-75 hover:opacity-100 active:translate-y-px md:hidden"
 				/>
 			</a>
 			<a href="/docs/accordion" class="link">
-				<span class="hidden lg:block"> Documentation </span>
-				<span class="block lg:hidden"> Docs </span>
-			</a>
+				<span class="hidden md:block">Docs</span>
+				<Book
+					class="h-6 w-6 text-white opacity-75 hover:opacity-100 active:translate-y-px md:hidden"
+				/></a
+			>
 		</div>
 	</nav>
 	<div class="flex grow flex-col">
@@ -69,7 +72,7 @@
 	</div>
 	<footer>
 		<div
-			class="flex flex-col items-start justify-between gap-2 px-6 py-4 lg:flex-row lg:items-center"
+			class="flex flex-col items-start justify-between gap-2 px-4 py-4 lg:flex-row lg:items-center"
 		>
 			<div class="flex flex-row gap-1">
 				<span class="flex gap-1 opacity-50">Inspired by</span>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
 	import '../app.postcss';
 
 	import '@fontsource/overpass/300.css';
@@ -15,10 +15,24 @@
 	import GitHub from '~icons/simple-icons/github';
 	import Discord from '~icons/simple-icons/discord';
 	import Book from '~icons/lucide/book';
+	import Menu from '~icons/lucide/menu';
+	import X from '~icons/lucide/x';
 	import { cn } from './helpers';
 	import { page } from '$app/stores';
+	import { writable } from 'svelte/store';
 	import { onMount } from 'svelte';
 	import { dev } from '$app/environment';
+	import { setContext } from 'svelte';
+
+	let isMenuOpen = writable(false);
+	setContext('menu', {
+		get() {
+			return isMenuOpen;
+		},
+		set(open: boolean) {
+			isMenuOpen.set(open);
+		},
+	});
 
 	$: isRoot = $page.url.pathname === '/';
 
@@ -32,7 +46,7 @@
 <main class="flex min-h-screen flex-col">
 	<nav
 		class={cn(
-			'flex items-center justify-between px-4 py-4 md:px-6 ',
+			'flex items-center justify-between px-4 py-4 lg:px-8 ',
 			!isRoot && 'border-b border-b-zinc-700'
 		)}
 	>
@@ -59,12 +73,30 @@
 					class="h-6 w-6 text-white opacity-75 hover:opacity-100 active:translate-y-px md:hidden"
 				/>
 			</a>
-			<a href="/docs/accordion" class="link">
-				<span class="hidden md:block">Docs</span>
-				<Book
-					class="h-6 w-6 text-white opacity-75 hover:opacity-100 active:translate-y-px md:hidden"
-				/></a
-			>
+			{#if isRoot}
+				<a href="/docs/accordion" class="link">
+					<span class="hidden md:block">Docs</span>
+					<Book
+						class="h-6 w-6 text-white opacity-75 hover:opacity-100 active:translate-y-px md:hidden"
+					/>
+				</a>
+			{:else if !$isMenuOpen}
+				<button
+					class="block h-6 w-6 md:hidden"
+					aria-label="Open menu"
+					on:click={() => ($isMenuOpen = true)}
+				>
+					<Menu class="h-6 w-6 text-white opacity-75 hover:opacity-100 active:translate-y-px" />
+				</button>
+			{:else if $isMenuOpen}
+				<button
+					class="block h-6 w-6 md:hidden"
+					aria-label="Close menu"
+					on:click={() => ($isMenuOpen = false)}
+				>
+					<X class="h-6 w-6 text-white opacity-75 hover:opacity-100 active:translate-y-px" />
+				</button>
+			{/if}
 		</div>
 	</nav>
 	<div class="flex grow flex-col">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -30,7 +30,7 @@
 </script>
 
 {#each { length: 6 } as _, n}
-	<div class="cummulative-gradient" style:--n={n + 1} />
+	<div class="cumulative-gradient" style:--n={n + 1} />
 {/each}
 
 <div class="relative grid grow place-items-center p-6">
@@ -42,23 +42,23 @@
 					>Radix Svelte is an unofficial community-led Svelte port of
 				</span><a href="https://radix-ui.com/" target="_blank" class="link">Radix UI Primitives</a
 				><span class="opacity-75"
-					>, a set of unstyled, accessible components for building high‑quality design systems and
+					>, a set of unstyled, accessible components for building high-quality design systems and
 					web apps.</span
 				>
 			</p>
 			<div class="flex flex-col gap-4 sm:flex-row">
 				<a
 					href="/docs/accordion"
-					class="text-md flex justify-between gap-4 rounded bg-vermilion-600 p-4 font-sans font-semibold text-white transition hover:bg-vermilion-500 active:translate-y-0.5 active:bg-vermilion-800 sm:shrink"
+					class="flex items-center justify-between gap-4 rounded bg-vermilion-600 px-4 py-3 font-sans text-lg font-semibold text-white transition hover:bg-vermilion-700 active:translate-y-0.5 active:bg-vermilion-700 sm:shrink"
 				>
 					Read the docs
 					<ArrowRight class="inline-block h-5 w-5 text-white" />
 				</a>
 				<button
 					on:click={copyInstallCommand}
-					class="text-md group flex justify-between gap-4 rounded bg-zinc-800 p-4 font-mono text-white transition hover:bg-zinc-700 active:translate-y-0.5 active:bg-zinc-900 sm:shrink"
+					class="group flex items-center justify-between gap-4 break-keep rounded bg-zinc-600 px-4 py-3 text-left font-mono text-lg text-white transition hover:bg-zinc-700 active:translate-y-0.5 active:bg-zinc-700 sm:shrink"
 					aria-label="Copy install command"
-					><span>npm install radix-svelte</span>
+					><span>npm install <span class="whitespace-nowrap">radix-svelte</span></span>
 					{#if copied}
 						<div in:fly={{ y: -4 }}>
 							<Check class="inline-block h-5 w-5 text-vermilion-500 transition" />
@@ -89,7 +89,7 @@
 </div>
 
 <style lang="postcss">
-	.cummulative-gradient {
+	.cumulative-gradient {
 		--size: calc(var(--n) * 20rem);
 
 		position: absolute;

--- a/src/routes/docs/[component]/+layout.svelte
+++ b/src/routes/docs/[component]/+layout.svelte
@@ -19,8 +19,8 @@
 	{@html theme}
 </svelte:head>
 
-<div class="flex grid-cols-12 flex-col gap-8 overflow-hidden py-2 lg:grid lg:px-6 lg:py-6">
-	<div class="col-span-2">
+<div class="flex max-w-full flex-col gap-8 py-2 lg:flex-row lg:px-6 lg:py-6">
+	<div class="w-auto min-w-[256px] lg:max-w-sm">
 		<ul class="flex w-full overflow-x-auto p-2 lg:flex-col">
 			{#each links as link}
 				<li>
@@ -37,10 +37,11 @@
 			{/each}
 		</ul>
 	</div>
-	<div class="col-span-8 flex flex-col items-center px-4 pt-2 lg:px-0">
-		<div class="w-full max-w-7xl">
-			<slot />
+	<div class="flex w-full justify-center overflow-y-auto">
+		<div class="w-full max-w-7xl items-center px-4 pt-2">
+			<div class="w-full">
+				<slot />
+			</div>
 		</div>
 	</div>
-	<div class="col-span-2" />
 </div>

--- a/src/routes/docs/[component]/+layout.svelte
+++ b/src/routes/docs/[component]/+layout.svelte
@@ -1,8 +1,18 @@
 <script lang="ts">
 	import theme from 'svelte-highlight/styles/tomorrow-night';
 	import { page } from '$app/stores';
+	import { getContext } from 'svelte';
 	import { schemas } from '$routes/(previews)/schemas';
 	import { cn, sortedEntries } from '$routes/helpers';
+	import type { Writable } from 'svelte/store';
+	import { afterNavigate } from '$app/navigation';
+
+	const menu = getContext('menu') as {
+		get(): Writable<boolean>;
+		set(open: boolean): void;
+	};
+
+	const isMenuOpen = menu.get();
 
 	type Link = {
 		title: string;
@@ -13,15 +23,29 @@
 		title: schema.title,
 		href: `/docs/${key}`,
 	}));
+
+	afterNavigate(() => {
+		$isMenuOpen = false;
+	});
 </script>
 
 <svelte:head>
 	{@html theme}
 </svelte:head>
 
-<div class="flex max-w-full flex-col gap-8 py-2 lg:flex-row lg:px-6 lg:py-6">
-	<div class="w-auto min-w-[256px] lg:max-w-sm">
-		<ul class="flex w-full overflow-x-auto p-2 lg:flex-col">
+<div class="flex max-w-full flex-col gap-8 py-2 md:flex-row md:px-6 md:py-6">
+	<div
+		class={cn(
+			$isMenuOpen ? 'block' : 'hidden md:block',
+			'z-10 w-full min-w-[256px] md:w-auto md:max-w-sm'
+		)}
+	>
+		<ul class="flex w-full flex-col p-2">
+			<li
+				class="text-md block whitespace-nowrap rounded-md border border-transparent px-3 py-2 text-sm font-semibold uppercase tracking-wider text-zinc-400"
+			>
+				Components
+			</li>
 			{#each links as link}
 				<li>
 					<a
@@ -31,13 +55,15 @@
 							'data-[active=true]:border-vermilion-600 data-[active=true]:bg-vermilion-600/25'
 						)}
 						data-active={$page.url.pathname === link.href}
-						href={link.href}>{link.title}</a
+						href={link.href}
 					>
+						{link.title}
+					</a>
 				</li>
 			{/each}
 		</ul>
 	</div>
-	<div class="flex w-full justify-center overflow-y-auto">
+	<div class={cn($isMenuOpen ? 'hidden md:flex' : 'flex', `w-full justify-center overflow-y-auto`)}>
 		<div class="w-full max-w-7xl items-center px-4 pt-2">
 			<div class="w-full">
 				<slot />

--- a/src/routes/docs/[component]/+page.svelte
+++ b/src/routes/docs/[component]/+page.svelte
@@ -125,7 +125,7 @@
 
 <div class="mt-8 flex flex-col gap-8">
 	{#each castMeta(cmpSchema) as [subCmp, subCmpSchema]}
-		<div>
+		<div class="flex w-full flex-col">
 			<h2 class="col-span-3 text-xl font-bold">{subCmp}</h2>
 			{#if subCmpSchema.description}
 				<p class="col-span-3 text-lg font-thin text-zinc-400">
@@ -134,96 +134,105 @@
 			{/if}
 
 			<div
-				class="mt-4 grid gap-x-4 gap-y-2 overflow-auto whitespace-nowrap rounded-md bg-zinc-900 p-4 text-white"
+				class="mt-4 flex grid-cols-1 flex-col gap-x-4 gap-y-2 overflow-auto whitespace-nowrap rounded-md bg-zinc-900 p-4 text-white md:grid md:grid-cols-5"
 			>
-				<span class=" text-sm text-zinc-300">Prop</span>
-				<span class=" text-sm text-zinc-300">Type</span>
-				<span class=" text-sm text-zinc-300">Control / Value</span>
+				<span class="col-span-1 hidden truncate text-sm text-zinc-300 lg:block">Prop</span>
+				<span class="col-span-2 hidden truncate text-sm text-zinc-300 lg:block">Type</span>
+				<span class="col-span-2 hidden truncate text-sm text-zinc-300 lg:block">Control/Value</span>
+				<span class="text-md block truncate text-zinc-300 lg:hidden">Props</span>
 
-				<hr class="col-span-3 opacity-25" />
+				<hr class="col-span-5 opacity-25" />
 
 				{#each castProps(subCmpSchema) as [propKey, propDefinition]}
-					<div>
-						<code class="font-mono">{propKey}</code>
-					</div>
-					<span class="font-mono">{propDefinition.typeLabel ?? propDefinition.type}</span>
-					<div class="">
-						{#if propDefinition.show === null}
-							<span class="white w-full font-mono text-sm"> N/A </span>
-						{:else if propDefinition.show === 'value'}
-							<span class="white w-full font-mono text-sm"
-								>{JSON.stringify(props[subCmp][propKey])}</span
-							>
-						{:else if propDefinition.type === 'boolean'}
-							<input type="checkbox" bind:checked={props[subCmp][propKey]} />
-						{:else if propDefinition.type === 'string'}
-							<input
-								class="w-full rounded-sm border border-zinc-400 bg-zinc-950 px-2 py-1 text-white"
-								type="text"
-								bind:value={props[subCmp][propKey]}
-							/>
-						{:else if propDefinition.type === 'number'}
-							<input
-								class="w-full rounded-sm border border-zinc-400 bg-zinc-950 px-2 py-1 text-white"
-								type="number"
-								bind:value={props[subCmp][propKey]}
-							/>
-						{:else if propDefinition.type === 'enum'}
-							<select
-								class="w-full rounded-sm border border-zinc-400 bg-zinc-950 px-2 py-1 text-white"
-								bind:value={props[subCmp][propKey]}
-							>
-								<option value="" hidden />
-								{#each propDefinition.options as value}
-									<option {value}>{value}</option>
-								{/each}
-							</select>
-						{:else}
-							{props[subCmp][propKey]}
-						{/if}
+					<div class="col-span-5 flex flex-col gap-x-4 gap-y-2 lg:grid lg:grid-cols-5">
+						<code class="col-span-1 max-w-fit truncate font-mono">{propKey}</code>
+						<span class="col-span-2 truncate font-mono"
+							>{propDefinition.typeLabel ?? propDefinition.type}</span
+						>
+						<div class="col-span-2">
+							{#if propDefinition.show === null}
+								<span class="white w-full truncate font-mono text-sm"> N/A </span>
+							{:else if propDefinition.show === 'value'}
+								<span class="white w-full truncate font-mono text-sm"
+									>{JSON.stringify(props[subCmp][propKey])}</span
+								>
+							{:else if propDefinition.type === 'boolean'}
+								<input type="checkbox" bind:checked={props[subCmp][propKey]} />
+							{:else if propDefinition.type === 'string'}
+								<input
+									class="w-full rounded-sm border border-zinc-400 bg-zinc-950 px-2 py-1 text-white"
+									type="text"
+									bind:value={props[subCmp][propKey]}
+								/>
+							{:else if propDefinition.type === 'number'}
+								<input
+									class="w-full rounded-sm border border-zinc-400 bg-zinc-950 px-2 py-1 text-white"
+									type="number"
+									bind:value={props[subCmp][propKey]}
+								/>
+							{:else if propDefinition.type === 'enum'}
+								<select
+									class="w-full rounded-sm border border-zinc-400 bg-zinc-950 px-2 py-1 text-white"
+									bind:value={props[subCmp][propKey]}
+								>
+									<option value="" hidden />
+									{#each propDefinition.options as value}
+										<option {value}>{value}</option>
+									{/each}
+								</select>
+							{:else}
+								{props[subCmp][propKey]}
+							{/if}
+						</div>
 					</div>
 				{:else}
-					<p class="col-span-3 text-sm">No props</p>
+					<p class="col-span-5 text-sm">No props</p>
 				{/each}
 
 				<!-- Events -->
 				{#if castEvents(subCmpSchema).length}
-					<hr class="col-span-3 h-4 opacity-0" />
+					<hr class="col-span-5 h-4 opacity-0" />
+					col-span-2
 
-					<span class=" text-sm text-zinc-300">Event</span>
-					<span class=" text-sm text-zinc-300">Payload</span>
-					<span class=" text-sm text-zinc-300" />
+					<span class="col-span-1 hidden truncate text-sm text-zinc-300 lg:block">Event</span>
+					<span class="col-span-2 hidden truncate text-sm text-zinc-300 lg:block">Payload</span>
+					<span class="col-span-2 hidden truncate text-sm text-zinc-300 lg:block" />
+					<span class="text-md block truncate text-zinc-300 lg:hidden">Events</span>
 
-					<hr class="col-span-3 opacity-25" />
+					<hr class="col-span-5 opacity-25" />
 
 					{#each castEvents(subCmpSchema) as [eventKey, eventDef]}
-						<span class=" font-mono">{eventKey}</span>
-						<span class=" font-mono">
+						<code class="col-span-1 max-w-fit truncate font-mono lg:max-w-none">{eventKey}</code>
+
+						<span class="col-span-2 truncate font-mono">
 							{Array.isArray(eventDef.payload)
 								? eventDef.payload.join(' | ')
 								: JSON.stringify(eventDef.payload)}
 						</span>
-						<div class="" />
+						<div class="col-span-2" />
 					{/each}
 				{/if}
 
 				<!-- Data Attributes -->
 				{#if castDataAttrs(subCmpSchema).length}
-					<hr class="col-span-3 h-4 opacity-0" />
+					<hr class="col-span-5 h-4 opacity-0" />
 
-					<span class=" text-sm text-zinc-300">Data Attribute</span>
-					<span class=" text-sm text-zinc-300">Value</span>
-					<span class=" text-sm text-zinc-300">Inspect</span>
+					<span class="col-span-1 hidden truncate text-sm text-zinc-300 lg:block"
+						>Data Attribute</span
+					>
+					<span class="col-span-2 hidden truncate text-sm text-zinc-300 lg:block">Value</span>
+					<span class="col-span-2 hidden truncate text-sm text-zinc-300 lg:block">Inspect</span>
+					<span class="text-md block truncate text-zinc-300 lg:hidden">Data Attributes</span>
 
-					<hr class="col-span-3 opacity-25" />
+					<hr class="col-span-5 opacity-25" />
 
 					{#each castDataAttrs(subCmpSchema) as [attrKey, attrDef]}
-						<span class="font-mono">[{attrKey}]</span>
-						<span class="font-mono">
+						<span class="col-span-1 truncate font-mono">[{attrKey}]</span>
+						<span class="col-span-2 truncate font-mono">
 							{Array.isArray(attrDef.values) ? attrDef.values.join(' | ') : attrDef.values}
 						</span>
 						<!-- How might we dynamically read the data attributes from the example? -->
-						<div class="" />
+						<div class="col-span-2" />
 					{/each}
 				{/if}
 			</div>

--- a/src/routes/docs/[component]/+page.svelte
+++ b/src/routes/docs/[component]/+page.svelte
@@ -54,6 +54,15 @@
 		return Object.entries((component.dataAttributes || {}) as Record<string, PreviewDataAttribute>);
 	}
 
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	function hasPropsOrEventsOrDataAttrs(component: any) {
+		return (
+			Object.keys(component.props || {}).length > 0 ||
+			Object.keys(component.events || {}).length > 0 ||
+			Object.keys(component.dataAttributes || {}).length > 0
+		);
+	}
+
 	let showCode = false;
 	$: {
 		$page.url.pathname;
@@ -133,109 +142,140 @@
 				</p>
 			{/if}
 
-			<div
-				class="mt-4 flex grid-cols-1 flex-col gap-x-4 gap-y-2 overflow-auto whitespace-nowrap rounded-md bg-zinc-900 p-4 text-white md:grid md:grid-cols-5"
-			>
-				<span class="col-span-1 hidden truncate text-sm text-zinc-300 lg:block">Prop</span>
-				<span class="col-span-2 hidden truncate text-sm text-zinc-300 lg:block">Type</span>
-				<span class="col-span-2 hidden truncate text-sm text-zinc-300 lg:block">Control/Value</span>
-				<span class="text-md block truncate text-zinc-300 lg:hidden">Props</span>
+			{#if !hasPropsOrEventsOrDataAttrs(subCmpSchema)}
+				<p class="col-span-3 text-lg font-thin text-zinc-400">
+					No props, events or data attributes are explicitly required.
+				</p>
+			{:else}
+				<div
+					class="mt-4 flex grid-cols-1 flex-col gap-4 overflow-auto whitespace-nowrap rounded-md bg-zinc-900 p-4 text-white"
+				>
+					{#if castProps(subCmpSchema).length}
+						<div class="grid grid-cols-5 gap-x-4 gap-y-2">
+							<span class="col-span-1 hidden truncate text-sm text-zinc-300 lg:block">Prop</span>
+							<span class="col-span-2 hidden truncate text-sm text-zinc-300 lg:block">Type</span>
+							<span class="col-span-2 hidden truncate text-sm text-zinc-300 lg:block"
+								>Control/Value</span
+							>
+							<span class="text-md col-span-full truncate text-zinc-300 lg:hidden">Props</span>
 
-				<hr class="col-span-5 opacity-25" />
+							<hr class="col-span-5 opacity-25" />
 
-				{#each castProps(subCmpSchema) as [propKey, propDefinition]}
-					<div class="col-span-5 flex flex-col gap-x-4 gap-y-2 lg:grid lg:grid-cols-5">
-						<code class="col-span-1 max-w-fit truncate font-mono">{propKey}</code>
-						<span class="col-span-2 truncate font-mono"
-							>{propDefinition.typeLabel ?? propDefinition.type}</span
-						>
-						<div class="col-span-2">
-							{#if propDefinition.show === null}
-								<span class="white w-full truncate font-mono text-sm"> N/A </span>
-							{:else if propDefinition.show === 'value'}
-								<span class="white w-full truncate font-mono text-sm"
-									>{JSON.stringify(props[subCmp][propKey])}</span
-								>
-							{:else if propDefinition.type === 'boolean'}
-								<input type="checkbox" bind:checked={props[subCmp][propKey]} />
-							{:else if propDefinition.type === 'string'}
-								<input
-									class="w-full rounded-sm border border-zinc-400 bg-zinc-950 px-2 py-1 text-white"
-									type="text"
-									bind:value={props[subCmp][propKey]}
-								/>
-							{:else if propDefinition.type === 'number'}
-								<input
-									class="w-full rounded-sm border border-zinc-400 bg-zinc-950 px-2 py-1 text-white"
-									type="number"
-									bind:value={props[subCmp][propKey]}
-								/>
-							{:else if propDefinition.type === 'enum'}
-								<select
-									class="w-full rounded-sm border border-zinc-400 bg-zinc-950 px-2 py-1 text-white"
-									bind:value={props[subCmp][propKey]}
-								>
-									<option value="" hidden />
-									{#each propDefinition.options as value}
-										<option {value}>{value}</option>
-									{/each}
-								</select>
-							{:else}
-								{props[subCmp][propKey]}
-							{/if}
+							<div class="col-span-5 divide-y divide-white divide-opacity-5 lg:divide-opacity-0">
+								{#each castProps(subCmpSchema) as [propKey, propDefinition]}
+									<div
+										class="col-span-5 flex flex-col gap-x-4 gap-y-2 py-3 lg:grid lg:grid-cols-5 lg:py-1"
+									>
+										<code class="col-span-1 max-w-fit truncate font-mono">{propKey}</code>
+										<span class="col-span-2 truncate font-mono"
+											>{propDefinition.typeLabel ?? propDefinition.type}</span
+										>
+										<div class="col-span-2">
+											{#if propDefinition.show === null}
+												<span class="white w-full truncate font-mono text-sm"> N/A </span>
+											{:else if propDefinition.show === 'value'}
+												<span class="white w-full truncate font-mono text-sm"
+													>{JSON.stringify(props[subCmp][propKey])}</span
+												>
+											{:else if propDefinition.type === 'boolean'}
+												<input type="checkbox" bind:checked={props[subCmp][propKey]} />
+											{:else if propDefinition.type === 'string'}
+												<input
+													class="w-full rounded-sm border border-zinc-400 bg-zinc-950 px-2 py-1 text-white"
+													type="text"
+													bind:value={props[subCmp][propKey]}
+												/>
+											{:else if propDefinition.type === 'number'}
+												<input
+													class="w-full rounded-sm border border-zinc-400 bg-zinc-950 px-2 py-1 text-white"
+													type="number"
+													bind:value={props[subCmp][propKey]}
+												/>
+											{:else if propDefinition.type === 'enum'}
+												<select
+													class="w-full rounded-sm border border-zinc-400 bg-zinc-950 px-2 py-1 text-white"
+													bind:value={props[subCmp][propKey]}
+												>
+													<option value="" hidden />
+													{#each propDefinition.options as value}
+														<option {value}>{value}</option>
+													{/each}
+												</select>
+											{:else}
+												{props[subCmp][propKey]}
+											{/if}
+										</div>
+									</div>
+								{/each}
+							</div>
 						</div>
-					</div>
-				{:else}
-					<p class="col-span-5 text-sm">No props</p>
-				{/each}
+					{/if}
 
-				<!-- Events -->
-				{#if castEvents(subCmpSchema).length}
-					<hr class="col-span-5 h-4 opacity-0" />
-					col-span-2
+					<!-- Events -->
 
-					<span class="col-span-1 hidden truncate text-sm text-zinc-300 lg:block">Event</span>
-					<span class="col-span-2 hidden truncate text-sm text-zinc-300 lg:block">Payload</span>
-					<span class="col-span-2 hidden truncate text-sm text-zinc-300 lg:block" />
-					<span class="text-md block truncate text-zinc-300 lg:hidden">Events</span>
+					{#if castEvents(subCmpSchema).length}
+						<div class="grid grid-cols-5 gap-x-4 gap-y-2">
+							<span class="col-span-1 hidden truncate text-sm text-zinc-300 lg:block">Event</span>
+							<span class="col-span-2 hidden truncate text-sm text-zinc-300 lg:block">Payload</span>
+							<span class="col-span-2 hidden truncate text-sm text-zinc-300 lg:block" />
+							<span class="text-md block truncate text-zinc-300 lg:hidden">Events</span>
 
-					<hr class="col-span-5 opacity-25" />
+							<hr class="col-span-5 opacity-25" />
 
-					{#each castEvents(subCmpSchema) as [eventKey, eventDef]}
-						<code class="col-span-1 max-w-fit truncate font-mono lg:max-w-none">{eventKey}</code>
+							<div class="col-span-5 divide-y divide-white divide-opacity-5 lg:divide-opacity-0">
+								{#each castEvents(subCmpSchema) as [eventKey, eventDef]}
+									<div
+										class="col-span-5 flex flex-col gap-x-4 gap-y-2 py-3 lg:grid lg:grid-cols-5 lg:py-1"
+									>
+										<code class="col-span-1 col-start-1 max-w-fit truncate font-mono lg:max-w-none"
+											>{eventKey}</code
+										>
 
-						<span class="col-span-2 truncate font-mono">
-							{Array.isArray(eventDef.payload)
-								? eventDef.payload.join(' | ')
-								: JSON.stringify(eventDef.payload)}
-						</span>
-						<div class="col-span-2" />
-					{/each}
-				{/if}
+										<span class="col-span-2 truncate font-mono">
+											{Array.isArray(eventDef.payload)
+												? eventDef.payload.join(' | ')
+												: JSON.stringify(eventDef.payload)}
+										</span>
+										<!-- <div class="col-span-2" /> -->
+									</div>
+								{/each}
+							</div>
+						</div>
+					{/if}
 
-				<!-- Data Attributes -->
-				{#if castDataAttrs(subCmpSchema).length}
-					<hr class="col-span-5 h-4 opacity-0" />
+					<!-- Data Attributes -->
 
-					<span class="col-span-1 hidden truncate text-sm text-zinc-300 lg:block"
-						>Data Attribute</span
-					>
-					<span class="col-span-2 hidden truncate text-sm text-zinc-300 lg:block">Value</span>
-					<span class="col-span-2 hidden truncate text-sm text-zinc-300 lg:block">Inspect</span>
-					<span class="text-md block truncate text-zinc-300 lg:hidden">Data Attributes</span>
+					{#if castDataAttrs(subCmpSchema).length}
+						<div class="grid grid-cols-5 gap-x-4 gap-y-2">
+							<span class="col-span-1 hidden truncate text-sm text-zinc-300 lg:block"
+								>Data Attribute</span
+							>
+							<span class="col-span-2 hidden truncate text-sm text-zinc-300 lg:block">Value</span>
+							<span class="col-span-2 hidden truncate text-sm text-zinc-300 lg:block">Inspect</span>
+							<span class="text-md col-span-full block truncate text-zinc-300 lg:hidden"
+								>Data Attributes</span
+							>
 
-					<hr class="col-span-5 opacity-25" />
+							<hr class="col-span-5 opacity-25" />
 
-					{#each castDataAttrs(subCmpSchema) as [attrKey, attrDef]}
-						<span class="col-span-1 truncate font-mono">[{attrKey}]</span>
-						<span class="col-span-2 truncate font-mono">
-							{Array.isArray(attrDef.values) ? attrDef.values.join(' | ') : attrDef.values}
-						</span>
-						<!-- How might we dynamically read the data attributes from the example? -->
-						<div class="col-span-2" />
-					{/each}
-				{/if}
-			</div>
+							<div class="col-span-5 divide-y divide-white divide-opacity-5 lg:divide-opacity-0">
+								{#each castDataAttrs(subCmpSchema) as [attrKey, attrDef]}
+									<div
+										class="col-span-5 flex flex-col gap-x-4 gap-y-2 py-3 lg:grid lg:grid-cols-5 lg:py-1"
+									>
+										<span class="col-span-1 col-start-1 truncate font-mono">[{attrKey}]</span>
+										<span class="col-span-2 truncate font-mono">
+											{Array.isArray(attrDef.values) ? attrDef.values.join(' | ') : attrDef.values}
+										</span>
+										<!-- How might we dynamically read the data attributes from the example? -->
+										<!-- <div class="col-span-2" /> -->
+									</div>
+								{/each}
+							</div>
+						</div>
+					{/if}
+				</div>
+			{/if}
 		</div>
 	{/each}
 </div>


### PR DESCRIPTION
- [x] Display props, events and data attributes in a column instead of a table
- [x] Use icons in the nav for docs, github and discord
- [x] Switch to flex and min-width instead of grid for sidenav and component docs for better tablet and ultra widescreen layouts
- [ ] Use sticky top and side navigation on component docs
- [x] Use hamburger menu and menu overlay on mobile and small tablets