### PR TITLE
align `<Dialog>`docs `modal` prop default value

### DIFF
--- a/.changeset/weak-penguins-marry.md
+++ b/.changeset/weak-penguins-marry.md
@@ -1,0 +1,5 @@
+---
+"radix-svelte": patch
+---
+
+Change `Dialog.Root` `modal` prop default from `false` to `true`

--- a/src/lib/components/Dialog/root.svelte
+++ b/src/lib/components/Dialog/root.svelte
@@ -18,7 +18,7 @@
 
 	const { getContext, setContext, defaults } = reactiveContext<DialogRootContext>({
 		open: false,
-		modal: false,
+		modal: true,
 		titleId: generateId(),
 		descriptionId: generateId(),
 		contentId: generateId(),

--- a/src/routes/(previews)/Dialog/schema.ts
+++ b/src/routes/(previews)/Dialog/schema.ts
@@ -19,7 +19,7 @@ export const schema = {
 				},
 				modal: {
 					type: 'boolean',
-					default: true,
+					default: false,
 				},
 			},
 		},

--- a/src/routes/(previews)/Dialog/schema.ts
+++ b/src/routes/(previews)/Dialog/schema.ts
@@ -19,7 +19,7 @@ export const schema = {
 				},
 				modal: {
 					type: 'boolean',
-					default: false,
+					default: true,
 				},
 			},
 		},


### PR DESCRIPTION
The docs for `<Dialog>` incorrectly show the `modal` prop as defaulting to true.

`modal` is defaulted to false in the code [here](https://github.com/TGlide/radix-svelte/blob/develop/src/lib/components/Dialog/root.svelte#L21), if I'm understanding it correctly.

