### PR TITLE
feat: improve scrollbar locking

### DIFF
--- a/.changeset/short-flowers-hope.md
+++ b/.changeset/short-flowers-hope.md
@@ -1,0 +1,5 @@
+---
+"radix-svelte": patch
+---
+
+feat: improve scrollbar locking (affects dialog and alert dialog)

--- a/src/lib/internal/actions/removeScroll.ts
+++ b/src/lib/internal/actions/removeScroll.ts
@@ -6,7 +6,16 @@ type Params = {
 
 export const removeScroll = ((node, params) => {
 	const update = (params: Params) => {
-		document.body.style.overflow = params.disable ? 'initial' : 'hidden';
+		if (!params.disable) document.body.style.top = `-${window.scrollY}px`;
+		document.body.style.position = params.disable ? '' : 'fixed';
+		document.body.style.overflowY = params.disable ? '' : 'scroll';
+		document.body.style.width = params.disable ? '' : '100%';
+
+		if (params.disable) {
+			const top = document.body.style.top.replaceAll(/[^0-9]/g, '') as unknown as number;
+			document.body.style.removeProperty('top');
+			window.scrollTo(window.scrollX, top);
+		}
 	};
 
 	update(params);

--- a/src/lib/internal/actions/removeScroll.ts
+++ b/src/lib/internal/actions/removeScroll.ts
@@ -12,7 +12,7 @@ export const removeScroll = ((node, params) => {
 		document.body.style.width = params.disable ? '' : '100%';
 
 		if (params.disable) {
-			const top = document.body.style.top.replaceAll(/[^0-9]/g, '') as unknown as number;
+			const top = document.body.style.top.replace(/[^0-9]/g, '') as unknown as number;
 			document.body.style.removeProperty('top');
 			window.scrollTo(window.scrollX, top);
 		}

--- a/src/lib/internal/actions/removeScroll.ts
+++ b/src/lib/internal/actions/removeScroll.ts
@@ -6,7 +6,10 @@ type Params = {
 
 export const removeScroll = ((node, params) => {
 	const update = (params: Params) => {
-		if (document.body.clientHeight > window.innerHeight) {
+		if (
+			document.body.clientHeight > window.innerHeight &&
+			window.getComputedStyle(document.body).overflowY !== 'hidden'
+		) {
 			if (!params.disable) document.body.style.top = `-${window.scrollY}px`;
 			document.body.style.position = params.disable ? '' : 'fixed';
 			document.body.style.overflowY = params.disable ? '' : 'scroll';

--- a/src/lib/internal/actions/removeScroll.ts
+++ b/src/lib/internal/actions/removeScroll.ts
@@ -6,15 +6,17 @@ type Params = {
 
 export const removeScroll = ((node, params) => {
 	const update = (params: Params) => {
-		if (!params.disable) document.body.style.top = `-${window.scrollY}px`;
-		document.body.style.position = params.disable ? '' : 'fixed';
-		document.body.style.overflowY = params.disable ? '' : 'scroll';
-		document.body.style.width = params.disable ? '' : '100%';
+		if (document.body.clientHeight > window.innerHeight) {
+			if (!params.disable) document.body.style.top = `-${window.scrollY}px`;
+			document.body.style.position = params.disable ? '' : 'fixed';
+			document.body.style.overflowY = params.disable ? '' : 'scroll';
+			document.body.style.width = params.disable ? '' : '100%';
 
-		if (params.disable) {
-			const top = document.body.style.top.replace(/[^0-9]/g, '') as unknown as number;
-			document.body.style.removeProperty('top');
-			window.scrollTo(window.scrollX, top);
+			if (params.disable) {
+				const top = document.body.style.top.replace(/[^0-9]/g, '') as unknown as number;
+				document.body.style.removeProperty('top');
+				window.scrollTo(window.scrollX, top);
+			}
 		}
 	};
 

--- a/src/lib/internal/actions/removeScroll.ts
+++ b/src/lib/internal/actions/removeScroll.ts
@@ -16,7 +16,7 @@ export const removeScroll = ((node, params) => {
 			document.body.style.width = params.disable ? '' : '100%';
 
 			if (params.disable) {
-				const top = document.body.style.top.replace(/[^0-9]/g, '') as unknown as number;
+				const top = Number(document.body.style.top.replace('-', '').replace('px', ''));
 				document.body.style.removeProperty('top');
 				window.scrollTo(window.scrollX, top);
 			}


### PR DESCRIPTION
The current implementation of the `removeScroll` action causes layout shifting and I personally find my scrollbar disappearing all together not as visually pleasing.